### PR TITLE
Token Config Data Structure Update

### DIFF
--- a/config/local-example.cjs
+++ b/config/local-example.cjs
@@ -16,7 +16,9 @@ module.exports = {
       'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx', // pinata.cloud api secret
   },
   algorand: {
-    token: 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+    token: {
+      'X-API-Key': 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx', // 'Your Purestake API Key'
+    },
     server: 'https://mainnet-algorand.api.purestake.io/ps2',
     port: '',
   },


### PR DESCRIPTION
users should use 'X-API-Key' rather than the token directly, especially when using Purestake.